### PR TITLE
Reads "Date created" field from event markers

### DIFF
--- a/bioread/biopac.py
+++ b/bioread/biopac.py
@@ -84,6 +84,28 @@ class Datafile(object):
         self.__time_index = np.linspace(0, total_seconds, total_samples)
         return self.__time_index
 
+    @property
+    def created_at(self):
+        """
+        Guess date at which the file was created by finding the
+        minimum date_created_utc from the event markers, or return
+        None if there are no markers our markers don't
+        have date_created_utc
+        """
+        if (
+            self.event_markers is None
+            or all([m.date_created_utc is None for m in self.event_markers])
+        ):
+            return None
+        min_event_time, min_event_idx = min(
+            (m.date_created_utc, idx) for (idx, m) in enumerate(self.event_markers))
+        # The time in ms from the beginning of the recording to the
+        # event with min_event_time:
+        delta_time_first_event = timedelta(milliseconds=
+            self.event_markers[min_event_idx].sample_index
+            * self.graph_header.sample_time)
+        return (min_event_time - delta_time_first_event).ctime()
+
     def __build_channels(self):
         return [
             Channel.from_headers(
@@ -256,7 +278,7 @@ class EventMarker(object):
         self.text = text
         self.channel_number = channel_number
         self.channel = channel
-        self.date_created_utc = (REF_DATE + timedelta(milliseconds=date_created_ms)).ctime() if date_created_ms else  None
+        self.date_created_utc = REF_DATE + timedelta(milliseconds=date_created_ms) if date_created_ms else  None
         self.type_code = type_code
         super(EventMarker, self).__init__()
 
@@ -274,7 +296,7 @@ class EventMarker(object):
             self.text,
             self.sample_index,
             self.channel_number,
-            self.date_created_utc,
+            self.date_created_utc.ctime(),
             self.type_code))
 
     def __repr__(self):

--- a/bioread/biopac.py
+++ b/bioread/biopac.py
@@ -10,6 +10,9 @@
 
 from __future__ import division
 import numpy as np
+from datetime import datetime, timezone, timedelta
+
+REF_DATE = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
 class Datafile(object):
@@ -246,12 +249,14 @@ class EventMarker(object):
             text,
             channel_number,
             channel=None,
+            date_created_ms=None,
             type_code=None):
 
         self.sample_index = sample_index
         self.text = text
         self.channel_number = channel_number
         self.channel = channel
+        self.date_created_utc = (REF_DATE + timedelta(milliseconds=date_created_ms)).ctime() if date_created_ms else  None
         self.type_code = type_code
         super(EventMarker, self).__init__()
 
@@ -260,14 +265,16 @@ class EventMarker(object):
             self.sample_index == other.sample_index,
             self.text == other.text,
             self.channel_number == other.channel_number,
+            self.date_created_utc == other.date_created_utc,
             self.type_code == other.type_code
         ])
 
     def __str__(self):
-        return("EventMarker {}: idx: {} channel: {} type_code: {}".format(
+        return("EventMarker {}: idx: {} channel: {} date_created_utc: {} type_code: {}".format(
             self.text,
             self.sample_index,
             self.channel_number,
+            self.date_created_utc,
             self.type_code))
 
     def __repr__(self):

--- a/bioread/headers.py
+++ b/bioread/headers.py
@@ -455,7 +455,7 @@ class PostMarkerHeader(BiopacHeader):
     def __h_elts(self):
         return VersionedHeaderStructure(
             ('hUnknown1', 'h', V_20a),
-            ('hUknnown2', 'h', V_20a),
+            ('hUnknown2', 'h', V_20a),
             ('lReps', 'l', V_20a),
             ('Unknown3', '80B', V_20a)
         )
@@ -765,6 +765,11 @@ class V2MarkerItemHeader(BiopacHeader):
         return None
 
     @property
+    def date_created_ms(self):
+        """ markers don't get "Date created" until v. 4.4.0 """
+        return None
+
+    @property
     def type_code(self):
         """ These markers don't get type_codes, but it's OK """
         return None
@@ -777,7 +782,7 @@ class V4MarkerItemHeader(BiopacHeader):
     """
 
     def __init__(self, file_revision, byte_order_char, **kwargs):
-        super().__init__(self.__h_elts, file_revision, byte_order_chari,
+        super().__init__(self.__h_elts, file_revision, byte_order_char,
                          **kwargs)
 
     @property
@@ -787,8 +792,8 @@ class V4MarkerItemHeader(BiopacHeader):
         ('Unknown'              ,'4B'   ,V_400B),
         ('nChannel'             ,'h'    ,V_400B),
         ('sMarkerStyle'         ,'4s'   ,V_400B),
-        ('Uknnown2'             ,'8B'   ,V_42x),
-        ('Uknnown3'             ,'8B'   ,V_440),
+        ('llDateCreated'        ,'Q'    ,V_440),
+        ('Unknown3'             ,'8B'   ,V_42x),
         ('nTextLength'          ,'h'    ,V_400B),
         )
 
@@ -808,6 +813,14 @@ class V4MarkerItemHeader(BiopacHeader):
         if chan == -1:
             chan = None
         return chan
+
+    @property
+    def date_created_ms(self):
+        """ Date when marker was created (in ms since 1970-01-01) """
+        if self.file_revision < V_440:
+            return None
+        else:
+            return self.data['llDateCreated']
 
     @property
     def type_code(self):

--- a/bioread/reader.py
+++ b/bioread/reader.py
@@ -288,7 +288,7 @@ class Reader(object):
             self.acq_file.seek(cch.compressed_data_offset)
             comp_data = self.acq_file.read(cch.compressed_data_len)
             decomp_data = zlib.decompress(comp_data)
-            channel.raw_data = np.fromstring(decomp_data, dtype=dt)
+            channel.raw_data = np.frombuffer(decomp_data, dtype=dt)
 
     def __read_data_uncompressed(self, channel_indexes, target_chunk_size):
         self.acq_file.seek(self.data_start_offset)
@@ -431,7 +431,7 @@ def read_chunks(f, buffers, byte_pattern, channel_indexes):
         chunk_bytes = len(pat)
         logger.debug('Chunk {0}: {1} bytes at {2}'.format(
             chunk_number, chunk_bytes, f.tell()))
-        chunk_data = np.fromstring(
+        chunk_data = np.frombuffer(
             f.read(chunk_bytes), dtype="b", count=chunk_bytes)
         update_buffers_with_data(
             chunk_data, buffers, pat, channel_indexes)

--- a/bioread/reader.py
+++ b/bioread/reader.py
@@ -266,6 +266,7 @@ class Reader(object):
                 text=marker_text,
                 channel_number=mih.channel_number,
                 channel=marker_channel,
+                date_created_ms=mih.date_created_ms,
                 type_code=mih.type_code))
         self.marker_item_headers = marker_item_headers
         self.datafile.marker_item_headers = marker_item_headers

--- a/bioread/runners/acq2hdf5.py
+++ b/bioread/runners/acq2hdf5.py
@@ -207,7 +207,7 @@ def save_markers(hdf5_file, datafile, dset_map):
             mg.attrs['type_code'] = m.type_code
             mg.attrs['type'] = m.type
         if m.date_created_utc:
-            mg.attrs['date_created'] = m.date_created_utc
+            mg.attrs['date_created'] = m.date_created_utc.ctime()
         if m.channel:
             mg.attrs['channel_number'] = m.channel_number
             cdset = dset_map[m.channel_number]

--- a/bioread/runners/acq2hdf5.py
+++ b/bioread/runners/acq2hdf5.py
@@ -206,6 +206,8 @@ def save_markers(hdf5_file, datafile, dset_map):
         if m.type_code:
             mg.attrs['type_code'] = m.type_code
             mg.attrs['type'] = m.type
+        if m.date_created_utc:
+            mg.attrs['date_created'] = m.date_created_utc
         if m.channel:
             mg.attrs['channel_number'] = m.channel_number
             cdset = dset_map[m.channel_number]

--- a/bioread/runners/acq_info.py
+++ b/bioread/runners/acq_info.py
@@ -96,6 +96,8 @@ class AcqInfoRunner(object):
         chs = self.reader.channel_headers
         cdhs = self.reader.channel_dtype_headers
         print("File revision: %s" % gh.file_revision)
+        if self.reader.datafile is not None:
+            print("Created: %s" % self.reader.datafile.created_at)
         print("Sample time: %s" % gh.sample_time)
         print("Compressed: %s" % gh.compressed)
         print("Number of channels: %s" % gh.channel_count)

--- a/bioread/runners/acq_markers.py
+++ b/bioread/runners/acq_markers.py
@@ -39,6 +39,7 @@ FIELDS = [
     'time (s)',
     'label',
     'channel',
+    'date_created',
     'type_code',
     'type'
 ]
@@ -60,6 +61,7 @@ def marker_formatter(acq_filename, graph_sample_msec):
             'time (s)': (marker.sample_index * graph_sample_msec) / 1000,
             'label': uf(marker.text),
             'channel': uf(marker.channel_name or 'Global'),
+            'date_created': uf(marker.date_created_utc or 'Unknown'),
             'type_code': uf(marker.type_code or 'None'),
             'type': uf(marker.type)
         }

--- a/bioread/runners/acq_markers.py
+++ b/bioread/runners/acq_markers.py
@@ -61,7 +61,7 @@ def marker_formatter(acq_filename, graph_sample_msec):
             'time (s)': (marker.sample_index * graph_sample_msec) / 1000,
             'label': uf(marker.text),
             'channel': uf(marker.channel_name or 'Global'),
-            'date_created': uf(marker.date_created_utc or 'Unknown'),
+            'date_created': uf(marker.date_created_utc.ctime() or 'Unknown'),
             'type_code': uf(marker.type_code or 'None'),
             'type': uf(marker.type)
         }

--- a/bioread/writers/matlabwriter.py
+++ b/bioread/writers/matlabwriter.py
@@ -64,6 +64,7 @@ class MatlabWriter(object):
                 'sample_index': marker.sample_index,
                 'type_code': marker.type_code or 'None',
                 'type': marker.type or 'None',
+                'date_created': marker.date_created_utc or 'None',
                 'channel_number': marker.channel_number or -1,
                 'channel': marker.channel_name or 'Global'
             }

--- a/bioread/writers/matlabwriter.py
+++ b/bioread/writers/matlabwriter.py
@@ -64,7 +64,7 @@ class MatlabWriter(object):
                 'sample_index': marker.sample_index,
                 'type_code': marker.type_code or 'None',
                 'type': marker.type or 'None',
-                'date_created': marker.date_created_utc or 'None',
+                'date_created': marker.date_created_utc.ctime() or 'None',
                 'channel_number': marker.channel_number or -1,
                 'channel': marker.channel_name or 'Global'
             }

--- a/test/test_acq_info.py
+++ b/test/test_acq_info.py
@@ -26,3 +26,4 @@ def test_acq_info_runs(capsys):
     acq_info.main([DATA_FILE])
     out, err = capsys.readouterr()
     assert len(out) > 0
+    assert 'Tue Feb  2 16:30:56 2016' in out

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -88,7 +88,7 @@ def test_reading(pathname):
     assert Reader.read(pathname), 'Error reading {0}'.format(pathname)
 
 
-@pytest.fixture(scope='module')
+#@pytest.fixture(scope='module')
 def canonical_files():
     versions = ['3.8.1', '4.1.0', '4.4.0']
     return dict(


### PR DESCRIPTION
I found that from AcqKnowledge v4.4.0 on, the date a marker is created is included with the marker.
With some reversed-engineering, I figured out it is encoded in `'Uknnown3'` (note the typo):
https://github.com/uwmadison-chm/bioread/blob/4641503e0c97df51551be224ceddcbad6963080f/bioread/headers.py#L791

This PR adds a new property `date_created_utc` for the class `EventMarker`, with the date it was created in UTC.  With a minor modification it could be modified to return it in the local timezone.

I think this solves #21 (for files created with AcqKnowledge v4.4.0 or later).