### PR TITLE
Add gzip decompression from file

### DIFF
--- a/bioread/reader.py
+++ b/bioread/reader.py
@@ -12,6 +12,8 @@
 from __future__ import with_statement, division
 import struct
 import zlib
+import gzip
+import io as pyio
 from contextlib import contextmanager
 
 import numpy as np
@@ -80,6 +82,14 @@ class Reader(object):
 
         returns: reader.Reader.
         """
+
+        # decompresses gzip file into memory
+        if isinstance(fo, str) and fo.endswith('.gz'):
+            with gzip.open(fo, 'rb') as compressed_fo:
+                decompressed_data = compressed_fo.read()
+                fo = pyio.BytesIO(decompressed_data)
+
+
         with open_or_yield(fo, 'rb') as io:
             reader = cls(io)
             reader._read_headers()


### PR DESCRIPTION
Hi.
I generally prefer to store my acqknowledge files in gzip format to save quite a bit of storage space. Using this package I have to usually add a bit of boilerplate to my code in order to read the gzipped file into an `io.BytesIO` object and then pass that into bioread. 

This works fine, but I was wondering if you would be open to allowing directly adding `.gz` files into the input of `bioread.read` which would do this boilerplate automatically. 

Thank you in advance for your time.